### PR TITLE
Add support for SignalR replicas

### DIFF
--- a/examples/serverless-signalr-with-replicas/.terraform.lock.hcl
+++ b/examples/serverless-signalr-with-replicas/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/azure/azapi" {
+  version = "2.0.1"
+  hashes = [
+    "h1:s+4lYMhi2JmalOV5CSOuZ81bnLdN5UY+LLgz3bdODcU=",
+    "zh:3df16ed604be5f4ccd5d52a02c2681d8eb2f5a4462625c983cb17c20cdf0bfb2",
+    "zh:4efd9961ea52990e21385086f0b3324edfb534ea6a8f0f6ba146a74bfb56aa63",
+    "zh:5561418efc9744c9873855a146226608778e29b4c0c3b3872634ef2da2d86593",
+    "zh:7ebcb4c6ca71c87850df67d4e5f79ce4a036d4131b8c11ae0b9b8787353843b8",
+    "zh:81a9259cb1e45507e9431794fbd354dd4d8b78c6a9508b0bfa108b00e6ad23cb",
+    "zh:8c1836fa186272347f97c7a3884556979618d1b93721e8a24203d90ff4efbd40",
+    "zh:a72bdd43a11a383525764720d24cb78ec5d9f1167f129d05448108fef1ba7af3",
+    "zh:ade9d17c6b8717e7b04af5a9d1a948d047ac4dcf6affb2485afa3ad0a2eaee15",
+    "zh:b3c5bfcab98251cb0c157dbe78dc6d0864c9bf364d316003c84c1e624a3c3524",
+    "zh:c33b872a2473a9b052add89e4557d361b0ebaa42865e99b95465050d2c858d43",
+    "zh:efe425f8ecd4d79448214c93ef10881b3b74cf2d9b5211d76f05aced22621eb4",
+    "zh:ff704c5e73e832507367d9d962b6b53c0ca3c724689f0974feffd5339c3db18a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.3.0"
+  constraints = "4.3.0"
+  hashes = [
+    "h1:fTnVSvgj8qXRZ9huFnRglu5sQexshjsVdk7b5eaOckc=",
+    "zh:117f843126f7a045ef4401103243ef53245a5c60b3fcf1f5f22bcb3a472c71fd",
+    "zh:4ae400db15d43a181527a585e51a237569631d49d685f9946212d1d9830f97ec",
+    "zh:53d9e7c9f42918e9cefe6469898c08975504a565e684a049365c43037ac9e3e3",
+    "zh:80f72cd97defcef1b23de85c5778499be44d5f034e3ecffdca161e1348602ffd",
+    "zh:826f716d13fd567bcd2db27cdab3c08fceb96542958512a6406ce389e82532ed",
+    "zh:9cd1ae99efa21bd90d8be47254c25b16f6e7ff9b3ba3ca2da5aaaa1695e9db16",
+    "zh:a2b78223937b5d7445e9d567f109044f94ffe178200559ed1401f4371b72b25f",
+    "zh:c7b5b4bfa05d90bc46cf300ec8d17a4554caef986c4c5fcf2610a492b78d65e7",
+    "zh:ccb3ebed6c701fd502cc41c486603e443c62086dbc1cee6f69c97fcb49e2181f",
+    "zh:d4d0edbdc373cbb94feffd0297289da2c1f5da36c1776f692151e98b7eadb1dd",
+    "zh:ee63964ad68a720e3ec399228db40e40a8321639adf3fbf47716252ee6e2f070",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.5.2"
+  constraints = "2.5.2"
+  hashes = [
+    "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}

--- a/examples/serverless-signalr-with-replicas/locals.tf
+++ b/examples/serverless-signalr-with-replicas/locals.tf
@@ -1,0 +1,15 @@
+locals {
+  application = "signalr"
+  environment = "loc"
+  location    = "northcentralus"
+  log_analytics_workspace = {
+    retention_period = 180
+    sku              = "PerGB2018"
+  }
+  signalr = {
+    service_mode = "Serverless"
+    tier         = "Free_F1"
+  }
+  tags   = {}
+  tenant = var.tenant
+}

--- a/examples/serverless-signalr-with-replicas/main.tf
+++ b/examples/serverless-signalr-with-replicas/main.tf
@@ -1,0 +1,54 @@
+# global naming conventions and resources
+module "globals" {
+  source = "../../modules/globals"
+
+  application = local.application
+  environment = local.environment
+  location    = local.location
+  tenant      = local.tenant
+}
+
+# resource group
+module "resource_group" {
+  source = "../../modules/resource_group"
+
+  application  = local.application
+  contributors = []
+  environment  = local.environment
+  location     = local.location
+  readers      = []
+  tags         = {}
+  tenant       = local.tenant
+}
+
+# serverless signalr
+module "signalr" {
+  source = "../../modules/signal_r"
+
+  providers = {
+    azapi = azapi
+  }
+
+  application               = local.application
+  capacity                  = 1
+  connectivity_logs_enabled = true
+  cors = {
+    allowed_origins = ["*"]
+  }
+  environment            = local.environment
+  location               = local.location
+  messaging_logs_enabled = true
+  replicas = [
+    {
+      location = "southcentralus"
+    },
+    {
+      location = "centralus",
+    }
+  ]
+  resource_group_name = module.resource_group.name
+  service_mode        = "Serverless"
+  sku                 = "Premium_P1"
+  tags                = {}
+  tenant              = local.tenant
+}

--- a/examples/serverless-signalr-with-replicas/terraform.tf
+++ b/examples/serverless-signalr-with-replicas/terraform.tf
@@ -1,0 +1,35 @@
+terraform {
+  backend "local" {}
+  required_version = "~> 1.9.8"
+  required_providers {
+    azapi = {
+      source = "azure/azapi"
+      version = "2.0.1"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.5.2"
+    }
+  }
+}
+
+provider "azapi" {
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+    key_vault {
+      purge_soft_delete_on_destroy    = false
+      recover_soft_deleted_key_vaults = false
+    }
+  }
+  subscription_id = var.subscription_id
+}
+

--- a/examples/serverless-signalr-with-replicas/variables.tf
+++ b/examples/serverless-signalr-with-replicas/variables.tf
@@ -1,0 +1,9 @@
+variable "subscription_id" {
+  description = "Defines the subscription in which resources will be provisioned"
+  type        = string
+}
+
+variable "tenant" {
+  description = "Defines the tenant name for whom the resources are being provisioned. In a development environment, this is typically the developer's last name."
+  type        = string
+}

--- a/modules/signal_r/main.tf
+++ b/modules/signal_r/main.tf
@@ -1,3 +1,20 @@
+locals {
+  # if the client code supplies a name, use it. otherwise, name the resource using the default naming convention.
+  name = coalesce(
+    var.name,
+    lower(
+      join(
+        "-",
+        [
+          module.globals.resource_base_name_long,
+          module.globals.role_names.notification,
+          module.globals.object_type_names.signalr
+        ]
+      )
+    )
+  )
+}
+
 # global naming conventions and resources
 module "globals" {
   source = "../globals"
@@ -21,16 +38,9 @@ resource "azurerm_signalr_service" "signalr" {
 
   location               = var.location
   messaging_logs_enabled = var.messaging_logs_enabled
-  name = join(
-    "-",
-    [
-      module.globals.resource_base_name_long,
-      module.globals.role_names.notification,
-      module.globals.object_type_names.signalr
-    ]
-  )
-  resource_group_name = var.resource_group_name
-  service_mode        = var.service_mode
+  name                   = local.name
+  resource_group_name    = var.resource_group_name
+  service_mode           = var.service_mode
 
   sku {
     name     = var.sku
@@ -38,4 +48,35 @@ resource "azurerm_signalr_service" "signalr" {
   }
 
   tags = var.tags
+}
+
+# signalr replica(s)
+#  at the time of this writing, there is no native terraform support for provisioning
+#  replicas. the azapi is used here instead.
+resource "azapi_resource" "signalr_replicas" {
+  for_each = {
+    for replica in var.replicas : replica.location => replica
+  }
+
+  type      = "Microsoft.SignalRService/signalR/replicas@2024-04-01-preview"
+  parent_id = azurerm_signalr_service.signalr.id
+  name = coalesce(
+    each.value.name,
+    replace(
+      local.name,
+      module.globals.location_short_name_list[var.location],
+      module.globals.location_short_name_list[each.value.location]
+    )
+  )
+  location = each.value.location
+  body = {
+    sku = {
+      name     = try(each.value.sku.name, var.sku)          # if sku name is not defined for the replica, use the same sku as the primary
+      capacity = try(each.value.sku.capacity, var.capacity) # if capacity is not defined for the replica, use the same capacity as the primay
+    }
+  }
+
+  depends_on = [
+    azurerm_signalr_service.signalr
+  ]
 }

--- a/modules/signal_r/outputs.tf
+++ b/modules/signal_r/outputs.tf
@@ -1,3 +1,8 @@
+output "name" {
+  value = azurerm_signalr_service.signalr.name
+  description = "The name that was assigned to the resource during provisioning."
+}
+
 output "primary_connection_string" {
   value       = azurerm_signalr_service.signalr.primary_connection_string
   description = "The connection string for the Signal R instance associated with the primary access key."

--- a/modules/signal_r/terraform.tf
+++ b/modules/signal_r/terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    azapi = {
+      source = "azure/azapi"
+      version = "2.0.1"
+    }
+  }
+}
+
+
+

--- a/modules/signal_r/variables.tf
+++ b/modules/signal_r/variables.tf
@@ -41,6 +41,32 @@ variable "messaging_logs_enabled" {
   description = "Specifies if tracing information for SignalR hub messages received and sent is turned on."
 }
 
+variable "name" {
+  type        = string
+  default     = null
+  description = "The name to give to the SignalR instance. If no name is provided, a default name will be used based on the global azure naming convention of this library."
+}
+
+variable "replicas" {
+  type = list(
+    object(
+      {
+        location = string
+        name     = optional(string)
+        sku = optional(
+          object(
+            {
+              name     = string
+              capacity = number
+            }
+          )
+        )
+      }
+    )
+  )
+  default = []
+}
+
 variable "resource_group_name" {
   type        = string
   description = "The name of the resource group in infrastructure will be provisioned."


### PR DESCRIPTION
This update allows provisioning of geo-replicas for a primary SignalR instance. Example code is also added to test and demonstrate.